### PR TITLE
Make the call to the API using HTTPS

### DIFF
--- a/lunametrics-youtube-v6.js
+++ b/lunametrics-youtube-v6.js
@@ -178,7 +178,7 @@ function getRealTitles(j) {
 		//We pray into the ether
 		//harken oh monster of youtube 
 		//tell us the truth of this noble video
-	    var tempJSON = $.getJSON('http://gdata.youtube.com/feeds/api/videos/'+videoArray[j]+'?v=2&alt=json',function(data,status,xhr){
+	    var tempJSON = $.getJSON('https://gdata.youtube.com/feeds/api/videos/'+videoArray[j]+'?v=2&alt=json',function(data,status,xhr){
 			//and lo the monster repsonds
 			//it's whispers flowing as mist
 			//through the mountain crag


### PR DESCRIPTION
If the site is using HTTPS, the call is blocked, so making the call with HTTPS by default is better.
