### PR TITLE
Fixes jshint errors

### DIFF
--- a/lunametrics-youtube.gtm.js
+++ b/lunametrics-youtube.gtm.js
@@ -1,4 +1,4 @@
-;(function(document, window, config) {
+(function(document, window, config) {
 
   'use strict';
 
@@ -51,9 +51,15 @@
       } else {
 
         // On IE8 this fires on window.load, all other browsers will fire when DOM ready
-        document.addEventListener ? 
-          addEvent(document, 'DOMContentLoaded', init) : 
+        if (document.addEventListener) {
+
+          addEvent(document, 'DOMContentLoaded', init);
+
+        } else {
+
           addEvent(window, 'load', init);
+
+        }
 
       }
 

--- a/src/lunametrics-youtube.gtm.js
+++ b/src/lunametrics-youtube.gtm.js
@@ -1,4 +1,4 @@
-;(function(document, window, config) {
+(function(document, window, config) {
 
   'use strict';
 
@@ -51,9 +51,15 @@
       } else {
 
         // On IE8 this fires on window.load, all other browsers will fire when DOM ready
-        document.addEventListener ? 
-          addEvent(document, 'DOMContentLoaded', init) : 
+        if (document.addEventListener) {
+
+          addEvent(document, 'DOMContentLoaded', init);
+
+        } else {
+
           addEvent(window, 'load', init);
+
+        }
 
       }
 


### PR DESCRIPTION
```
$ grunt
Running "jshint:files" (jshint) task

   src/lunametrics-youtube.gtm.js
     56 |          addEvent(window, 'load', init);
                                                ^ Expected an assignment or function call and instead saw an expression.

>> 1 error in 1 file
Warning: Task "jshint:files" failed. Use --force to continue.

Aborted due to warnings.
```
